### PR TITLE
[point] Adds support for boosts and drops

### DIFF
--- a/packages/point/package.json
+++ b/packages/point/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "^24.0.18",
+    "@types/uuid": "^3.4.5",
     "jest": "^24.9.0",
     "ts-jest": "^24.0.2",
     "tslint": "^5.19.0",
@@ -33,6 +34,8 @@
     ]
   },
   "dependencies": {
-    "typescript-memoize": "^1.0.0-alpha.3"
+    "@xethya/utils": "^0.1.2",
+    "typescript-memoize": "^1.0.0-alpha.3",
+    "uuid": "^3.3.3"
   }
 }

--- a/packages/point/package.json
+++ b/packages/point/package.json
@@ -31,5 +31,8 @@
     "transformIgnorePatterns": [
       "/node_modules/[^@xethya]/"
     ]
+  },
+  "dependencies": {
+    "typescript-memoize": "^1.0.0-alpha.3"
   }
 }

--- a/packages/point/package.json
+++ b/packages/point/package.json
@@ -34,7 +34,7 @@
     ]
   },
   "dependencies": {
-    "@xethya/utils": "^0.1.2",
+    "@xethya/utils": "^0.1.4",
     "typescript-memoize": "^1.0.0-alpha.3",
     "uuid": "^3.3.3"
   }

--- a/packages/point/package.json
+++ b/packages/point/package.json
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "@xethya/utils": "^0.1.4",
-    "typescript-memoize": "^1.0.0-alpha.3",
     "uuid": "^3.3.3"
   }
 }

--- a/packages/point/src/point.ts
+++ b/packages/point/src/point.ts
@@ -1,1 +1,321 @@
-export class Point {}
+import { array, assert, Collection, numeric, Range } from "@xethya/utils";
+import { v4 as generateUUID } from "uuid";
+
+const { byKey } = array.mappers;
+const { bySum } = array.reducers;
+const { formatThousands } = numeric;
+
+export const enum ModifierType {
+  /**
+   * A boost represents an increase in the score.
+   */
+  Boost = "B",
+
+  /**
+   * A drop represents a decrease in the score.
+   */
+  Drop = "D",
+}
+
+export type Modifier = {
+  /**
+   * A unique identifier for this modifier. Generated internally.
+   * It uses the uuid.v4() hash function.
+   */
+  id: string;
+
+  /**
+   * By how much would the score be affected, whether it is a boost
+   * or a drop.
+   */
+  factor: number;
+
+  /**
+   * Why is this boost or drop occuring.
+   */
+  reason?: string;
+
+  /**
+   * Whether this modifier is a boost (B) or a drop (D).
+   */
+  type: ModifierType;
+};
+
+export type PointOptions = {
+  /**
+   * The name of this score.
+   */
+  name: string;
+
+  /**
+   * The unit of this score, such as HP, MP or XP.
+   */
+  unit?: string;
+
+  /**
+   * The initial score this point instance starts with.
+   */
+  initialScore: number;
+
+  /**
+   * The minimum score this counter can handle. Defaults to -Infinity.
+   */
+  minimumScore?: number;
+
+  /**
+   * The maximum score this counter can handle. Defaults to +Infinity.
+   */
+  maximumScore?: number;
+};
+
+export type PointFormatOptions = {
+  /**
+   * Whether to format the score value as thousands (i.e. 1,000,000).
+   */
+  formatScoreInThousands: boolean;
+
+  /**
+   * Whether to show the unit name along the value (i.e. 1,000,000 HP).
+   */
+  showUnit: boolean;
+
+  /**
+   * The separator to use when splitting thousands (i.e. "," or ".").
+   */
+  thousandSeparator?: string;
+};
+
+export class Point {
+  /**
+   * The name of this score.
+   */
+  public name: string;
+
+  /**
+   * The unit of this score, such as HP, MP or XP.
+   */
+  public unit: string;
+
+  /**
+   * The initial score this point instance starts with.
+   */
+  public initialScore: number;
+
+  /**
+   * How low or how high the score counter can go.
+   */
+  public range: Range;
+
+  /**
+   * A list of factors that permanently affect the computed value of the point.
+   */
+  protected readonly permanentModifiers: Collection<Modifier>;
+
+  /**
+   * A list of factors that temporarily affect the computed value of the point.
+   * Unlike permanent modifiers, these can be removed.
+   */
+  protected readonly temporaryModifiers: Collection<Modifier>;
+
+  protected lastScore: number = 0;
+
+  protected lastModifierCount: number = -1;
+
+  /**
+   * Points are cumulative units that can reflect different features of a creature.
+   * Some examples would be hit points (how many hits a creature can take before dying
+   * or being destroyed), magic points (how much magical energy a creature is holding)
+   * or experience points (how much has a creature progressed in its life,
+   * raising its "level" and therefore other points).
+   */
+  constructor(options: PointOptions) {
+    this.name = options.name;
+    this.unit = options.unit || "";
+    this.initialScore = options.initialScore;
+    this.lastScore = this.initialScore;
+    this.range = new Range(
+      options.minimumScore === undefined ? -Infinity : options.minimumScore,
+      options.maximumScore === undefined ? Infinity : options.maximumScore,
+    );
+
+    assert(
+      this.range.includes(this.initialScore),
+      `initialScore must be within the specified range: ${this.range.toString()}`,
+    );
+
+    this.permanentModifiers = new Collection<Modifier>("id");
+    this.temporaryModifiers = new Collection<Modifier>("id");
+
+    this.permanentModifiers.onBeforeAdd(this.checkForValidModifier.bind(this));
+    this.permanentModifiers.onBeforeAdd(this.increaseModifierCount.bind(this));
+    this.permanentModifiers.onAdd(this.updateLastScore.bind(this));
+
+    this.temporaryModifiers.onBeforeAdd(this.checkForValidModifier.bind(this));
+    this.temporaryModifiers.onBeforeAdd(this.increaseModifierCount.bind(this));
+    this.temporaryModifiers.onBeforeRemove(this.decreaseModifierCount.bind(this));
+    this.temporaryModifiers.onAdd(this.updateLastScore.bind(this));
+    this.temporaryModifiers.onRemove(this.updateLastScore.bind(this));
+  }
+
+  protected increaseModifierCount() {
+    this.lastModifierCount += 1;
+  }
+
+  protected decreaseModifierCount() {
+    this.lastModifierCount -= 1;
+  }
+
+  protected updateLastScore(_: Collection<Modifier>, modifier: Modifier) {
+    this.lastScore += modifier.factor;
+  }
+
+  /**
+   * Verifies that the modifier has a valid factor and keeps the score range in check.
+   * Triggered by the `before:add` event of the modifier collections.
+   *
+   * @param modifier The modifier being added either permanently or temporarily.
+   */
+  protected checkForValidModifier(collection: Collection<Modifier>, modifier: Modifier) {
+    const { factor, type } = modifier;
+    const isPermanent = collection === this.permanentModifiers;
+
+    if (type === ModifierType.Boost) {
+      assert(factor > 0, "Point changes must use a factor greater than zero");
+      assert(
+        this.range.includes(this.lastScore + factor),
+        `Boosting ${isPermanent ? "permanently" : "temporarily"} by ${factor} makes the score ${
+          this.lastScore
+        }, which goes out of the range ${this.range.toString()}`,
+      );
+    }
+
+    if (type === ModifierType.Drop) {
+      assert(factor < 0, "Point changes must use a factor greater than zero");
+      assert(
+        this.range.includes(this.lastScore - factor),
+        `Dropping ${isPermanent ? "permanently" : "temporarily"} by ${factor} makes the score ${
+          this.lastScore
+        }, which goes out of the range ${this.range.toString()}`,
+      );
+    }
+  }
+
+  /**
+   * Records a permanent boost into this point counter.
+   *
+   * @param factor How much this boost would increment the score.
+   * @param reason Why is this boost occuring.
+   */
+  public boostPermanentlyBy(factor: number, reason?: string) {
+    this.permanentModifiers.add({ id: generateUUID(), factor, reason, type: ModifierType.Boost });
+  }
+
+  /**
+   * Records a permanent drop into this point counter.
+   *
+   * @param factor How much this drop would decrement the score.
+   * @param reason Why is this drop occuring.
+   */
+  public dropPermanentlyBy(factor: number, reason?: string) {
+    this.permanentModifiers.add({ id: generateUUID(), factor: -factor, reason, type: ModifierType.Drop });
+  }
+
+  /**
+   * Records a temporary boost into this point counter. Temporary boosts can
+   * be canceled using the `revertTemporaryEffect` method.
+   *
+   * @param factor How much this boost would increment the score.
+   * @param reason Why is this boost occuring.
+   */
+  public boostTemporarilyBy(factor: number, reason?: string): Modifier {
+    const modifier = { id: generateUUID(), factor, reason, type: ModifierType.Boost };
+    this.temporaryModifiers.add(modifier);
+
+    return modifier;
+  }
+
+  /**
+   * Records a temporary drop into this point counter. Temporary drops can
+   * be canceled using the `revertTemporaryEffect` method.
+   *
+   * @param factor How much this drop would decrement the score.
+   * @param reason Why is this drop occuring.
+   */
+  public dropTemporarilyBy(factor: number, reason?: string) {
+    const modifier = { id: generateUUID(), factor: -factor, reason, type: ModifierType.Drop };
+    this.temporaryModifiers.add(modifier);
+
+    return modifier;
+  }
+
+  /**
+   * Cancels a given boost or drop, reverting its effects.
+   *
+   * @param modifier The boost or drop to revert, returned by either `boostTemporarilyBy`
+   *                 or `dropTemporarilyBy`.
+   */
+  public revertTemporaryEffect(modifier: Modifier) {
+    this.temporaryModifiers.remove(modifier.id);
+  }
+
+  /**
+   * Calculates the total sum of all permanent modifiers.
+   */
+  private get permanentFactorSum(): number {
+    if (!this.permanentModifiers.count) {
+      return 0;
+    }
+
+    return this.permanentModifiers
+      .getAll()
+      .map(byKey("factor"))
+      .reduce(bySum);
+  }
+
+  /**
+   * Calculates the total sum of all temporary modifiers.
+   */
+  private get temporaryFactorSum(): number {
+    if (!this.temporaryModifiers.count) {
+      return 0;
+    }
+
+    return this.temporaryModifiers
+      .getAll()
+      .map(byKey("factor"))
+      .reduce(bySum);
+  }
+
+  /**
+   * Calculates the current score in the point counter.
+   */
+  public get score(): number {
+    if (this.lastModifierCount === this.permanentModifiers.count + this.temporaryModifiers.count) {
+      return this.lastScore;
+    }
+
+    const score = this.initialScore + this.permanentFactorSum + this.temporaryFactorSum;
+    this.lastScore = score;
+
+    return score;
+  }
+
+  /**
+   * Returns a string representation of the point counter's current score.
+   *
+   * @param formatOptions Allows to configure different aspects of how the string will look.
+   */
+  public toString(
+    formatOptions: PointFormatOptions = {
+      formatScoreInThousands: true,
+      showUnit: true,
+      thousandSeparator: ".",
+    },
+  ): string {
+    const { formatScoreInThousands, showUnit, thousandSeparator } = formatOptions;
+
+    const score = formatScoreInThousands ? formatThousands(this.score, thousandSeparator) : this.score;
+    const unit = showUnit ? ` ${this.unit}` : "";
+    return `${score}${unit}`;
+  }
+}

--- a/packages/point/tests/point.test.ts
+++ b/packages/point/tests/point.test.ts
@@ -1,7 +1,75 @@
 import { Point } from "../src/point";
 
 describe("Point", () => {
+  let healthPoints: Point;
+
+  beforeEach(() => {
+    healthPoints = new Point({
+      name: "Health Points",
+      unit: "HP",
+      initialScore: 100,
+      minimumScore: 0,
+      maximumScore: 150,
+    });
+  });
+
   it("can be instantiated", () => {
-    expect(new Point()).toBeDefined();
+    expect(healthPoints.name).toEqual("Health Points");
+    expect(healthPoints.unit).toEqual("HP");
+    expect(healthPoints.initialScore).toEqual(100);
+    expect(healthPoints.range.lowerBound).toEqual(0);
+    expect(healthPoints.range.upperBound).toEqual(150);
+    expect(healthPoints.score).toEqual(100);
+  });
+
+  it("can't be affected with a negative number", () => {
+    expect(() => healthPoints.boostPermanentlyBy(-10, "I'm crazy")).toThrow(/greater than zero/);
+    expect(() => healthPoints.dropPermanentlyBy(-10, "I'm crazy")).toThrow(/greater than zero/);
+    expect(() => healthPoints.boostTemporarilyBy(-10, "I'm crazy")).toThrow(/greater than zero/);
+    expect(() => healthPoints.dropTemporarilyBy(-10, "I'm crazy")).toThrow(/greater than zero/);
+  });
+
+  it("can't be affected with zero", () => {
+    expect(() => healthPoints.boostPermanentlyBy(0, "I'm crazy")).toThrow(/greater than zero/);
+    expect(() => healthPoints.dropPermanentlyBy(0, "I'm crazy")).toThrow(/greater than zero/);
+    expect(() => healthPoints.boostTemporarilyBy(0, "I'm crazy")).toThrow(/greater than zero/);
+    expect(() => healthPoints.dropTemporarilyBy(0, "I'm crazy")).toThrow(/greater than zero/);
+  });
+
+  it("can be boosted permanently", () => {
+    healthPoints.boostPermanentlyBy(10);
+    expect(healthPoints.score).toEqual(110);
+  });
+
+  it("can be boosted temporarily", () => {
+    const boost = healthPoints.boostTemporarilyBy(10);
+    expect(healthPoints.score).toEqual(110);
+
+    healthPoints.revertTemporaryEffect(boost);
+    expect(healthPoints.score).toEqual(100);
+  });
+
+  it("can be dropped permanently", () => {
+    healthPoints.dropPermanentlyBy(10);
+    expect(healthPoints.score).toEqual(90);
+  });
+
+  it("can be dropped temporarily", () => {
+    const drop = healthPoints.dropTemporarilyBy(10);
+    expect(healthPoints.score).toEqual(90);
+
+    healthPoints.revertTemporaryEffect(drop);
+    expect(healthPoints.score).toEqual(100);
+  });
+
+  it("can have a million modifiers", () => {
+    for (let i = 0; i < 1000000; i += 1) {
+      if (i % 2 === 0) {
+        healthPoints.boostPermanentlyBy(0.2);
+      } else {
+        healthPoints.dropTemporarilyBy(0.2);
+      }
+    }
+    expect(healthPoints.score).toEqual(100);
   });
 });

--- a/packages/point/tests/point.test.ts
+++ b/packages/point/tests/point.test.ts
@@ -19,7 +19,7 @@ describe("Point", () => {
     expect(healthPoints.initialScore).toEqual(100);
     expect(healthPoints.range.lowerBound).toEqual(0);
     expect(healthPoints.range.upperBound).toEqual(150);
-    expect(healthPoints.score).toEqual(100);
+    expect(healthPoints.getScore()).toEqual(100);
   });
 
   it("can't be affected with a negative number", () => {
@@ -38,38 +38,48 @@ describe("Point", () => {
 
   it("can be boosted permanently", () => {
     healthPoints.boostPermanentlyBy(10);
-    expect(healthPoints.score).toEqual(110);
+    expect(healthPoints.getScore()).toEqual(110);
   });
 
   it("can be boosted temporarily", () => {
     const boost = healthPoints.boostTemporarilyBy(10);
-    expect(healthPoints.score).toEqual(110);
+    expect(healthPoints.getScore()).toEqual(110);
 
     healthPoints.revertTemporaryEffect(boost);
-    expect(healthPoints.score).toEqual(100);
+    expect(healthPoints.getScore()).toEqual(100);
   });
 
   it("can be dropped permanently", () => {
     healthPoints.dropPermanentlyBy(10);
-    expect(healthPoints.score).toEqual(90);
+    expect(healthPoints.getScore()).toEqual(90);
   });
 
   it("can be dropped temporarily", () => {
     const drop = healthPoints.dropTemporarilyBy(10);
-    expect(healthPoints.score).toEqual(90);
+    expect(healthPoints.getScore()).toEqual(90);
 
     healthPoints.revertTemporaryEffect(drop);
-    expect(healthPoints.score).toEqual(100);
+    expect(healthPoints.getScore()).toEqual(100);
   });
 
-  it("can have a million modifiers", () => {
-    for (let i = 0; i < 1000000; i += 1) {
-      if (i % 2 === 0) {
-        healthPoints.boostPermanentlyBy(0.2);
-      } else {
-        healthPoints.dropTemporarilyBy(0.2);
-      }
-    }
-    expect(healthPoints.score).toEqual(100);
+  it("can't be affected by out of range boosts/drops", () => {
+    expect(() => healthPoints.boostPermanentlyBy(110, "I'm crazy")).toThrow(/out of the range/);
+    expect(() => healthPoints.dropPermanentlyBy(110, "I'm crazy")).toThrow(/out of the range/);
+    expect(() => healthPoints.boostTemporarilyBy(110, "I'm crazy")).toThrow(/out of the range/);
+    expect(() => healthPoints.dropTemporarilyBy(110, "I'm crazy")).toThrow(/out of the range/);
+  });
+
+  it("can be printed as a string", () => {
+    /**
+     * @todo This shouldn't be possible.
+     * @see https://github.com/xethya/framework/issues/43
+     */
+    healthPoints.range.upperBound = 1000;
+    healthPoints.boostPermanentlyBy(900);
+
+    expect(healthPoints.toString()).toEqual("1.000 HP");
+    expect(healthPoints.toString({ showUnit: false })).toEqual("1.000");
+    expect(healthPoints.toString({ showUnit: false, formatScoreInThousands: false })).toEqual("1000");
+    expect(healthPoints.toString({ thousandSeparator: "," })).toEqual("1,000 HP");
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,6 +2046,11 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+core-js@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
+  integrity sha1-TekR5mew6ukSTjQlS1OupvxhjT4=
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -6295,6 +6300,13 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript-memoize@^1.0.0-alpha.3:
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.0.0-alpha.3.tgz#699a5415f886694a8d6e2e5451bc28a39a6bc2f9"
+  integrity sha1-aZpUFfiGaUqNbi5UUbwoo5prwvk=
+  dependencies:
+    core-js "2.4.1"
 
 typescript@^3.5.3:
   version "3.5.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,11 +2046,6 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-core-js@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
-  integrity sha1-TekR5mew6ukSTjQlS1OupvxhjT4=
-
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -6300,13 +6295,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-typescript-memoize@^1.0.0-alpha.3:
-  version "1.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.0.0-alpha.3.tgz#699a5415f886694a8d6e2e5451bc28a39a6bc2f9"
-  integrity sha1-aZpUFfiGaUqNbi5UUbwoo5prwvk=
-  dependencies:
-    core-js "2.4.1"
 
 typescript@^3.5.3:
   version "3.5.3"


### PR DESCRIPTION
A _boost_ is an increase to the score in the `Point`, while a _drop_ is a decrease in the score. Both can be registered permanently or temporarily.

Resolves #37.