### PR TITLE
[point] Add support for scores with calculations

### DIFF
--- a/packages/point/package.json
+++ b/packages/point/package.json
@@ -34,7 +34,7 @@
     ]
   },
   "dependencies": {
-    "@xethya/utils": "^0.1.4",
+    "@xethya/utils": "^0.1.5",
     "uuid": "^3.3.3"
   }
 }

--- a/packages/point/src/point.ts
+++ b/packages/point/src/point.ts
@@ -118,8 +118,19 @@ export class Point {
    */
   protected readonly temporaryModifiers: Collection<Modifier>;
 
+  /**
+   * Stores the latest score calculation.
+   */
   protected lastScore: number = 0;
+
+  /**
+   * Stores the latest boost or drop registered.
+   */
   protected lastModifier: Modifier;
+
+  /**
+   * Stores the amount of boosts or drops registered so far.
+   */
   protected lastModifierCount: number = 0;
 
   /**
@@ -158,21 +169,34 @@ export class Point {
     this.temporaryModifiers.onRemove(this.decreaseModifierCount.bind(this));
   }
 
-  protected increaseModifierCount(_: Collection<Modifier>, modifier: Modifier) {
+  /**
+   * Used to update how many modifiers have been registered so far.
+   * Triggers after adding either a temporary or permanent modifier.
+   */
+  protected increaseModifierCount() {
     this.lastModifierCount += 1;
   }
 
-  protected decreaseModifierCount(_: Collection<Modifier>, modifier: Modifier) {
+  /**
+   * Used to update how many modifiers have been registered so far.
+   * Triggers after removing a temporary modifier.
+   */
+  protected decreaseModifierCount() {
     this.lastModifierCount -= 1;
   }
 
+  /**
+   * Updates the score counter with the latest boost or drop that was added or removed.
+   *
+   * @param collection The list of modifiers being affected.
+   */
   protected updateLastScore(collection: Collection<Modifier>) {
     let factor = this.lastModifier.factor;
+    const isTemporaryModifier = collection === this.temporaryModifiers;
+    const isRemovingModifier =
+      this.lastModifierCount - 1 === this.permanentModifiers.count + this.temporaryModifiers.count;
 
-    if (
-      collection === this.temporaryModifiers &&
-      this.lastModifierCount - 1 === this.permanentModifiers.count + this.temporaryModifiers.count
-    ) {
+    if (isTemporaryModifier && isRemovingModifier) {
       factor = -factor;
     }
 

--- a/packages/point/tests/point.test.ts
+++ b/packages/point/tests/point.test.ts
@@ -82,4 +82,34 @@ describe("Point", () => {
     expect(healthPoints.toString({ showUnit: false, formatScoreInThousands: false })).toEqual("1000");
     expect(healthPoints.toString({ thousandSeparator: "," })).toEqual("1,000 HP");
   });
+
+  it("can be calculated with external dependencies", () => {
+    let foo = 30;
+    const boostWithFoo = () => foo / 2;
+
+    healthPoints.addCalculation(boostWithFoo);
+
+    expect(healthPoints.getScore()).toEqual(115);
+
+    foo = 50;
+    expect(healthPoints.getScore()).toEqual(125);
+  });
+
+  it("can't overflow the range with calculations", () => {
+    const foo = 200;
+    const dropWithFoo = () => -foo;
+
+    healthPoints.addCalculation(dropWithFoo);
+    expect(() => healthPoints.getScore()).toThrow(/exceeds score range/);
+  });
+
+  it("can return the score without calculations", () => {
+    const foo = 30;
+    const boostWithFoo = () => foo / 2;
+
+    healthPoints.addCalculation(boostWithFoo);
+
+    expect(healthPoints.getScore()).toEqual(115);
+    expect(healthPoints.getLastScore()).toEqual(100);
+  });
 });


### PR DESCRIPTION
A calculation is a function that returns a number.

When added to a `Point` instance, it allows boosting or dropping to the score with dynamic, external factors.

Resolves #38.