### PR TITLE
[creature] Adds support for Hit Points

### DIFF
--- a/packages/creature/package.json
+++ b/packages/creature/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@xethya/ability": "^0.0.3",
     "@xethya/definitions": "^0.0.4",
+    "@xethya/point": "^0.0.3",
     "@xethya/race": "^0.0.1",
     "uuid": "^3.3.3"
   }

--- a/packages/creature/src/creature.ts
+++ b/packages/creature/src/creature.ts
@@ -1,23 +1,99 @@
 import Ability from "@xethya/ability";
 import { CreatureAlignment, CreatureSize } from "@xethya/definitions";
+import { Point } from "@xethya/point";
 import { Race } from "@xethya/race";
 import { v4 as generateUUID } from "uuid";
 
 export type CreatureOptions = {
+  /**
+   * Describes to which races this creature belongs.
+   */
   races?: Race[];
+
+  /**
+   * Specifies the creature's size.
+   */
   size?: CreatureSize;
+
+  /**
+   * Determines the creature's morality and attitude towards society and order.
+   */
   alignment?: CreatureAlignment;
+
+  /**
+   * A common denomination for the creature.
+   */
   name?: string;
+
+  /**
+   * The maximum hit points the creature will have.
+   */
+  hitPoints?: number;
+
+  /**
+   * Binds an ability modifier to the hit points calculation.
+   */
+  abilityForHitPoints?: Ability;
+};
+
+/**
+ * Specifies an amount of hit points for each defined CreatureSize.
+ *
+ * @see https://www.dandwiki.com/wiki/5e_SRD:Creatures#Hit_Points_by_Size
+ */
+const sizeToHitPoints: { [key in CreatureSize]: number } = {
+  [CreatureSize.Fine]: 3,
+  [CreatureSize.Diminutive]: 4,
+  [CreatureSize.Tiny]: 5,
+  [CreatureSize.Small]: 7,
+  [CreatureSize.Medium]: 9,
+  [CreatureSize.Large]: 11,
+  [CreatureSize.Huge]: 13,
+  [CreatureSize.Gargantuan]: 21,
+  [CreatureSize.Colossal]: 33,
 };
 
 export class Creature {
+  /**
+   * Describes to which races this creature belongs.
+   */
   public readonly races: Race[] = [];
+
+  /**
+   * Stores all of the creature's abilities.
+   */
   public readonly abilities: Map<string, Ability>;
+
+  /**
+   * Specifies the creature's size.
+   */
   public readonly size: CreatureSize = CreatureSize.Medium;
+
+  /**
+   * Determines the creature's morality and attitude towards society and order.
+   */
   public readonly alignment: CreatureAlignment = CreatureAlignment.Neutral;
+
+  /**
+   * Contains a unique identifier for this instance.
+   */
   public readonly id: string;
+
+  /**
+   * A common denomination for the creature.
+   */
   public readonly name: string = "Unknown Creature";
 
+  /**
+   * Counts how many hits the creature can sustain.
+   */
+  public readonly hitPoints: Point;
+
+  /**
+   * Represents a lifeform.
+   *
+   * @param options Configures how this creature will behave.
+   */
   public constructor(options: CreatureOptions = {}) {
     this.id = generateUUID();
     this.abilities = new Map<string, Ability>();
@@ -47,6 +123,20 @@ export class Creature {
 
     if (options.alignment) {
       this.alignment = options.alignment;
+    }
+
+    const hitPointScore = options.hitPoints || sizeToHitPoints[this.size];
+    this.hitPoints = new Point({
+      name: "Hit Points",
+      unit: "HP",
+      minimumScore: 0,
+      maximumScore: hitPointScore,
+      initialScore: hitPointScore,
+    });
+
+    if (options.abilityForHitPoints) {
+      this.abilities.set(options.abilityForHitPoints.id, options.abilityForHitPoints);
+      this.hitPoints.addCalculation(() => options.abilityForHitPoints.modifier);
     }
   }
 }

--- a/packages/creature/tests/creature.test.ts
+++ b/packages/creature/tests/creature.test.ts
@@ -80,4 +80,38 @@ describe("Creature", () => {
     expect(creature.size).toEqual(CreatureSize.Medium);
     expect(creature.alignment).toEqual(CreatureAlignment.Neutral);
   });
+
+  it("should have arbitrary hit points", () => {
+    const creature = new Creature({ hitPoints: 100 });
+    expect(creature.hitPoints.getScore()).toEqual(100);
+  });
+
+  it("should have hit points by its size", () => {
+    const fineCreature = new Creature({ size: CreatureSize.Fine });
+    expect(fineCreature.hitPoints.getScore()).toEqual(3);
+
+    const diminituveCreature = new Creature({ size: CreatureSize.Diminutive });
+    expect(diminituveCreature.hitPoints.getScore()).toEqual(4);
+
+    const tinyCreature = new Creature({ size: CreatureSize.Tiny });
+    expect(tinyCreature.hitPoints.getScore()).toEqual(5);
+
+    const smallCreature = new Creature({ size: CreatureSize.Small });
+    expect(smallCreature.hitPoints.getScore()).toEqual(7);
+
+    const mediumCreature = new Creature({ size: CreatureSize.Medium });
+    expect(mediumCreature.hitPoints.getScore()).toEqual(9);
+
+    const largeCreature = new Creature({ size: CreatureSize.Large });
+    expect(largeCreature.hitPoints.getScore()).toEqual(11);
+
+    const hugeCreature = new Creature({ size: CreatureSize.Huge });
+    expect(hugeCreature.hitPoints.getScore()).toEqual(13);
+
+    const gargantuanCreature = new Creature({ size: CreatureSize.Gargantuan });
+    expect(gargantuanCreature.hitPoints.getScore()).toEqual(21);
+
+    const colossalCreature = new Creature({ size: CreatureSize.Colossal });
+    expect(colossalCreature.hitPoints.getScore()).toEqual(33);
+  });
 });


### PR DESCRIPTION
This PR adds support for implementing hit points into a creature definition.

Resolves #50.