### PR TITLE
[publish process] Sets all packages to "public"

### DIFF
--- a/packages/ability/package.json
+++ b/packages/ability/package.json
@@ -21,6 +21,9 @@
     "test": "jest --runInBand --detectOpenHandles --bail --forceExit",
     "test:coverage": "jest --runInBand --detectOpenHandles --bail --forceExit --coverage"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jest": {
     "preset": "ts-jest",
     "collectCoverageFrom": [

--- a/packages/creature/package.json
+++ b/packages/creature/package.json
@@ -22,6 +22,9 @@
     "test": "jest --runInBand --detectOpenHandles --bail --forceExit",
     "test:coverage": "jest --runInBand --detectOpenHandles --bail --forceExit --coverage"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jest": {
     "preset": "ts-jest",
     "collectCoverageFrom": [

--- a/packages/definitions/package.json
+++ b/packages/definitions/package.json
@@ -21,6 +21,9 @@
     "test": "echo 'No tests apply.'",
     "test:coverage": "echo 'No tests apply.'"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jest": {
     "preset": "ts-jest"
   }

--- a/packages/dice/package.json
+++ b/packages/dice/package.json
@@ -27,6 +27,9 @@
     "test": "jest --runInBand --detectOpenHandles --bail --forceExit",
     "test:coverage": "jest --runInBand --detectOpenHandles --bail --forceExit --coverage"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jest": {
     "preset": "ts-jest",
     "collectCoverageFrom": [

--- a/packages/gamebook-dnd-5e/package.json
+++ b/packages/gamebook-dnd-5e/package.json
@@ -21,6 +21,9 @@
     "test": "jest --runInBand --detectOpenHandles --bail --forceExit",
     "test:coverage": "jest --runInBand --detectOpenHandles --bail --forceExit --coverage"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jest": {
     "preset": "ts-jest",
     "collectCoverageFrom": [

--- a/packages/inventory/package.json
+++ b/packages/inventory/package.json
@@ -26,6 +26,9 @@
     "test": "jest --runInBand --detectOpenHandles --bail --forceExit",
     "test:coverage": "jest --runInBand --detectOpenHandles --bail --forceExit --coverage"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jest": {
     "preset": "ts-jest",
     "collectCoverageFrom": [

--- a/packages/point/package.json
+++ b/packages/point/package.json
@@ -27,6 +27,9 @@
     "test": "jest --runInBand --detectOpenHandles --bail --forceExit",
     "test:coverage": "jest --runInBand --detectOpenHandles --bail --forceExit --coverage"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jest": {
     "preset": "ts-jest",
     "collectCoverageFrom": [

--- a/packages/race/package.json
+++ b/packages/race/package.json
@@ -23,6 +23,9 @@
     "test": "jest --runInBand --detectOpenHandles --bail --forceExit",
     "test:coverage": "jest --runInBand --detectOpenHandles --bail --forceExit --coverage"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jest": {
     "preset": "ts-jest",
     "collectCoverageFrom": [

--- a/packages/random-blum-blum-shub/package.json
+++ b/packages/random-blum-blum-shub/package.json
@@ -24,6 +24,9 @@
     "test": "jest --runInBand --detectOpenHandles --bail --forceExit",
     "test:coverage": "jest --runInBand --detectOpenHandles --bail --forceExit --coverage"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jest": {
     "preset": "ts-jest",
     "collectCoverageFrom": [

--- a/packages/random-core/package.json
+++ b/packages/random-core/package.json
@@ -21,6 +21,9 @@
     "test": "#jest --runInBand --detectOpenHandles --bail --forceExit",
     "test:coverage": "#jest --runInBand --detectOpenHandles --bail --forceExit --coverage"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jest": {
     "preset": "ts-jest",
     "collectCoverageFrom": [

--- a/packages/random-mersenne-twister/package.json
+++ b/packages/random-mersenne-twister/package.json
@@ -25,6 +25,9 @@
     "test": "jest --runInBand --detectOpenHandles --bail --forceExit",
     "test:coverage": "jest --runInBand --detectOpenHandles --bail --forceExit --coverage"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jest": {
     "preset": "ts-jest",
     "collectCoverageFrom": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -28,6 +28,9 @@
     "test": "jest --runInBand --detectOpenHandles --bail --forceExit",
     "test:coverage": "jest --runInBand --detectOpenHandles --bail --forceExit --coverage"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jest": {
     "preset": "ts-jest",
     "collectCoverageFrom": [

--- a/tools/package-create.js
+++ b/tools/package-create.js
@@ -52,6 +52,9 @@ const templatePackageJson = `
     "test": "jest --runInBand --detectOpenHandles --bail --forceExit",
     "test:coverage": "jest --runInBand --detectOpenHandles --bail --forceExit --coverage"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jest": {
     "preset": "ts-jest",
     "collectCoverageFrom": [


### PR DESCRIPTION
Fixes the `lerna` error on private packages that occurred in the latest workflow runs of the publisher.