### PR TITLE
[item] Spins up new new package from `inventory/src/item`

### DIFF
--- a/packages/item/package.json
+++ b/packages/item/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@xethya/item",
+  "shortName": "item",
+  "version": "0.0.1",
+  "description": "",
+  "main": "dist/xethya.item.js",
+  "module": "dist/xethya.item.es.js",
+  "iife": "dist/xethya.item.iife.js",
+  "repository": "https://github.com/xethya/framework",
+  "author": "Joel A. Villarreal Bertoldi",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/jest": "^24.0.18",
+    "@types/uuid": "^3.4.5",
+    "jest": "^24.9.0",
+    "rollup": "^1.20.1",
+    "rollup-plugin-json": "^4.0.0",
+    "rollup-plugin-typescript2": "^0.24.0",
+    "ts-jest": "^24.0.2",
+    "tslint": "^5.19.0",
+    "typescript": "^3.5.3"
+  },
+  "scripts": {
+    "build": "tsc -b && rollup -c",
+    "test": "jest --runInBand --detectOpenHandles --bail --forceExit",
+    "test:coverage": "jest --runInBand --detectOpenHandles --bail --forceExit --coverage"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "collectCoverageFrom": [
+      "src/**/*.ts",
+      "!**/index.ts",
+      "!**/errors.ts"
+    ],
+    "transformIgnorePatterns": [
+      "/node_modules/[^@xethya]/"
+    ]
+  },
+  "dependencies": {
+    "uuid": "^3.3.3"
+  }
+}

--- a/packages/item/rollup.config.js
+++ b/packages/item/rollup.config.js
@@ -1,0 +1,41 @@
+import json from "rollup-plugin-json";
+import typescript from "rollup-plugin-typescript2";
+import pkg from "./package.json";
+
+const globals = {
+  uuid: "uuid",
+};
+
+export default [
+  {
+    input: "src/index.ts",
+    output: [
+      {
+        file: pkg.main,
+        sourcemap: true,
+        format: "cjs",
+        globals: globals,
+      },
+      {
+        file: pkg.module,
+        sourcemap: true,
+        format: "es",
+        globals: globals,
+      },
+      {
+        file: pkg.iife,
+        sourcemap: true,
+        format: "iife",
+        name: "xethya." + pkg.shortName,
+        globals: globals,
+      },
+    ],
+    external: [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})],
+    plugins: [
+      typescript({
+        typescript: require("typescript"),
+      }),
+      json({ compact: true }),
+    ],
+  },
+];

--- a/packages/item/src/index.ts
+++ b/packages/item/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./item";

--- a/packages/item/src/item.ts
+++ b/packages/item/src/item.ts
@@ -1,0 +1,39 @@
+import { v4 as generateUUID } from "uuid";
+
+export const ITEM_DEFAULT_WEIGHT = 1;
+
+/**
+ * Customizes the item's features.
+ */
+export type ItemOptions = {
+  /**
+   * How much this item weights. Defaults to ITEM_DEFAULT_WEIGHT (1).
+   *
+   * @default 1
+   */
+  weight?: number;
+};
+
+export class Item {
+  /**
+   * A unique identifier for the item.
+   */
+  public readonly id: string;
+
+  /**
+   * How much this item weights. Defaults to ITEM_DEFAULT_WEIGHT (1).
+   *
+   * @default 1
+   */
+  public readonly weight: number;
+
+  /**
+   * Represents something an entity can hold and/or use.
+   *
+   * @param options {ItemOptions}
+   */
+  constructor(options: ItemOptions = {}) {
+    this.id = generateUUID();
+    this.weight = options.weight || ITEM_DEFAULT_WEIGHT;
+  }
+}

--- a/packages/item/tests/item.test.ts
+++ b/packages/item/tests/item.test.ts
@@ -1,0 +1,17 @@
+import { Item, ITEM_DEFAULT_WEIGHT } from "../src/item";
+
+/**
+ * @todo Move this regex to utils.
+ * @see https://github.com/xethya/framework/issues/33
+ */
+const UUID_REGEX = /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/;
+
+describe("Item", () => {
+  describe("Basic instantiation", () => {
+    it("can be instantiated with default settings", () => {
+      const item = new Item();
+      expect(item.id).toMatch(UUID_REGEX);
+      expect(item.weight).toEqual(ITEM_DEFAULT_WEIGHT);
+    });
+  });
+});

--- a/packages/item/tsconfig.json
+++ b/packages/item/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./src"
+  },
+  "include": ["./src"]
+}

--- a/packages/item/tslint.json
+++ b/packages/item/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../tslint.json"]
+}


### PR DESCRIPTION
Contributes to #95. A follow-up PR will adjust `@xethya/inventory` to consume this new package.